### PR TITLE
Update Translation.php

### DIFF
--- a/src/Translation.php
+++ b/src/Translation.php
@@ -109,10 +109,10 @@ class Translation
         if (count($this->config) > 1) {
             $query = http_build_query($this->config);
 
-            return $this->api.$query.'&q='.$text;
+            return $this->api.$query.'&q='.urlencode($text);
         }
 
-        return $this->api.'keyfrom='.config('services.youdao.from').'&key='.config('services.youdao.key').'&q='.$text;
+        return $this->api.'keyfrom='.config('services.youdao.from').'&key='.config('services.youdao.key').'&q='.urlencode($text);
     }
 
     /**


### PR DESCRIPTION
Fixing Error：

> FatalThrowableError in Translation.php line 83:
Type error: Argument 1 passed to JellyBool\Translug\Translation::getTranslation() must be of the type array, null given

调用：

> Translug::translate('test 标题');